### PR TITLE
feat: Implement popup button UI (resolve #2)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_APP_TAG=ai-everywhere

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -2,83 +2,83 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+// :root {
+//   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+//   line-height: 1.5;
+//   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+//   color-scheme: light dark;
+//   color: rgba(255, 255, 255, 0.87);
+//   background-color: #242424;
 
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
+//   font-synthesis: none;
+//   text-rendering: optimizeLegibility;
+//   -webkit-font-smoothing: antialiased;
+//   -moz-osx-font-smoothing: grayscale;
+//   -webkit-text-size-adjust: 100%;
+// }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
+// a {
+//   font-weight: 500;
+//   color: #646cff;
+//   text-decoration: inherit;
+// }
+// a:hover {
+//   color: #535bf2;
+// }
 
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
+// body {
+//   margin: 0;
+//   display: flex;
+//   place-items: center;
+//   min-width: 320px;
+//   min-height: 100vh;
+// }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
+// h1 {
+//   font-size: 3.2em;
+//   line-height: 1.1;
+// }
 
-.card {
-  padding: 2em;
-}
+// .card {
+//   padding: 2em;
+// }
 
-#app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
+// #app {
+//   max-width: 1280px;
+//   margin: 0 auto;
+//   padding: 2rem;
+//   text-align: center;
+// }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
+// button {
+//   border-radius: 8px;
+//   border: 1px solid transparent;
+//   padding: 0.6em 1.2em;
+//   font-size: 1em;
+//   font-weight: 500;
+//   font-family: inherit;
+//   background-color: #1a1a1a;
+//   cursor: pointer;
+//   transition: border-color 0.25s;
+// }
+// button:hover {
+//   border-color: #646cff;
+// }
+// button:focus,
+// button:focus-visible {
+//   outline: 4px auto -webkit-focus-ring-color;
+// }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}
+// @media (prefers-color-scheme: light) {
+//   :root {
+//     color: #213547;
+//     background-color: #ffffff;
+//   }
+//   a:hover {
+//     color: #747bff;
+//   }
+//   button {
+//     background-color: #f9f9f9;
+//   }
+// }

--- a/src/content-script/App.svelte
+++ b/src/content-script/App.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import FloatingButton from './components/FloatingButton.svelte';
+
+  let section: HTMLElement;
+</script>
+
+<div id="everywhere">
+  <section
+    class="fixed top-1/2 left-1/2 z-[9999999999] w-auto"
+    bind:this={section}
+  >
+    <FloatingButton />
+  </section>
+</div>

--- a/src/content-script/components/FloatingButton.svelte
+++ b/src/content-script/components/FloatingButton.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { base64 } from '~/assets/logo.png?base64=20&run';
+  import { fade, fly } from 'svelte/transition';
+
+  let button: HTMLElement;
+</script>
+
+<button
+  bind:this={button}
+  class="cursor-pointer select-none bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-2 rounded"
+>
+  <img src={base64} alt="Logo" class="pointer-events-none select-none" />
+</button>

--- a/src/content-script/index.ts
+++ b/src/content-script/index.ts
@@ -1,3 +1,16 @@
-console.info('chrome-ext template-svelte-ts content script');
+import App from './App.svelte';
+import tailwind from '~/assets/app.scss?inline';
+// 새 엘리먼트 생성
+const everywhere = document.createElement(import.meta.env.VITE_APP_TAG);
+// html에 추가
 
-export {};
+document.documentElement.appendChild(everywhere);
+
+const shadowRoot = everywhere.attachShadow({ mode: 'open' });
+shadowRoot.innerHTML = `<style>${tailwind}</style>`;
+
+const app = new App({
+  target: shadowRoot,
+});
+
+export default app;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,27 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+
+declare module '*.svelte' {
+  import type { ComponentType } from 'svelte';
+  const component: ComponentType;
+  export default component;
+}
+declare module '*&imagetools' {
+  /**
+   * actual types
+   * - code https://github.com/JonasKruckenberg/imagetools/blob/main/packages/core/src/output-formats.ts
+   * - docs https://github.com/JonasKruckenberg/imagetools/blob/main/docs/guide/getting-started.md#metadata
+   */
+  const out;
+  export default out;
+}
+
+declare module '*&run' {
+  const src: string;
+  const width: number;
+  const height: number;
+  const format: string;
+  const base64: string;
+
+  export { src, width, height, format, base64 };
+}


### PR DESCRIPTION
This commit adds a button in the center using a content-script.

All CSS is isolated from the site using Shadow DOM.
It is wrapped with a custom tag name from the .env file.

The imagetools plugin is customized to work without type errors.
Its contents are added to the d.ts file.

Additionally, the button's image is resized and encoded in base64 using the imagetools tool.
This is done before the image is added to the button.